### PR TITLE
Potential fix for code scanning alert no. 115: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -92,17 +92,18 @@ jobs:
           echo "$github_actor"
           echo "github_actor=$github_actor" >> $GITHUB_ENV
 
-      - name: Store Slack infos
-        #because the SSH can be enabled dynamically if the workflow failed, so we need to store slack infos to be able to retrieve them during the waitforssh step
-        shell: bash
-        run: |
-          echo "${{ env.github_actor }}"
-          if [ "${{ secrets[format('{0}_{1}', env.github_actor, 'SLACK_ID')] }}" != "" ]; then
-            echo "SLACKCHANNEL=${{ secrets[format('{0}_{1}', env.github_actor, 'SLACK_ID')] }}" >> $GITHUB_ENV
-          else
-            echo "SLACKCHANNEL=${{ secrets.SLACK_CIFEEDBACK_CHANNEL }}" >> $GITHUB_ENV
-          fi
+      # Set SLACKCHANNEL for known actors explicitly, fall back to default
+      - name: Set Slack channel for alice
+        if: env.github_actor == 'alice'
+        run: echo "SLACKCHANNEL=${{ secrets.ALICE_SLACK_ID }}" >> $GITHUB_ENV
 
+      - name: Set Slack channel for bob
+        if: env.github_actor == 'bob'
+        run: echo "SLACKCHANNEL=${{ secrets.BOB_SLACK_ID }}" >> $GITHUB_ENV
+
+      - name: Set default Slack channel
+        if: ${{ ! (env.github_actor == 'alice' || env.github_actor == 'bob') }}
+        run: echo "SLACKCHANNEL=${{ secrets.SLACK_CIFEEDBACK_CHANNEL }}" >> $GITHUB_ENV
       - name: Tailscale # In order to be able to SSH when a test fails
         uses: huggingface/tailscale-action@main
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/115](https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/115)

To fix the problem, avoid using dynamic secret access via `${{ secrets[... ] }}` or `format`. Instead, enumerate the possible cases with explicit secret references for each case, using either [job conditional steps](https://docs.github.com/en/actions/using-jobs/using-job-conditions) or [matrix strategy](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs), or match on known actors with if-else logic in workflow YAML.

For this case:
- Replace the block that dynamically sets `SLACKCHANNEL` with several blocks, one per known actor, each using an explicit reference to the right `secrets.X_SLACK_ID`.
- Use `if:` conditionals to set the environment variable for each actor.
- Add a fallback for unknown actors to use the default `SLACK_CIFEEDBACK_CHANNEL`.

**Specifically:**
- In job `ssh_runner`, steps 95-105, replace the dynamic access block with multiple steps, each for a specific actor, e.g.:
  - if `github_actor` is "alice", set `SLACKCHANNEL=${{ secrets.ALICE_SLACK_ID }}`
  - if `github_actor` is "bob", set `SLACKCHANNEL=${{ secrets.BOB_SLACK_ID }}`
- At the end, add a fallback for all other cases to set `SLACKCHANNEL=${{ secrets.SLACK_CIFEEDBACK_CHANNEL }}`.

You will need to enumerate all actors who may trigger the workflow and for whom you maintain a secret. This maintains least-privilege by only exposing referenced secrets to the runner.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
