### PR TITLE
Potential fix for code scanning alert no. 126: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -54,13 +54,13 @@ jobs:
       - name: Prepare some setup values
         run: |
           if [ -f setup_values/prev_workflow_run_id.txt ]; then
-            echo "PREV_WORKFLOW_RUN_ID=$(cat setup_values/prev_workflow_run_id.txt)" >> $GITHUB_ENV
+            echo "PREV_WORKFLOW_RUN_ID=$(cat setup_values/prev_workflow_run_id.txt | tr -d '\n\r')" >> $GITHUB_ENV
           else
             echo "PREV_WORKFLOW_RUN_ID=" >> $GITHUB_ENV
           fi
 
           if [ -f setup_values/other_workflow_run_id.txt ]; then
-            echo "OTHER_WORKFLOW_RUN_ID=$(cat setup_values/other_workflow_run_id.txt)" >> $GITHUB_ENV
+            echo "OTHER_WORKFLOW_RUN_ID=$(cat setup_values/other_workflow_run_id.txt | tr -d '\n\r')" >> $GITHUB_ENV
           else
             echo "OTHER_WORKFLOW_RUN_ID=" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/126](https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/126)

To prevent environment variable injection, the file contents must be sanitized before being appended to `$GITHUB_ENV`. The best way is to strip any newline or carriage return characters from the file contents when constructing the environment variable. In Bash, you can do this by piping the file content through `tr -d '\n\r'`, which removes newlines and carriage returns, ensuring that the injected value does not break the intended format of the environment variable and cannot inject a new assignment. The fix should only touch the `run` block of the affected step (`Prepare some setup values`) and should not introduce new dependencies or alter the core logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
