### PR TITLE
Potential fix for code scanning alert no. 132: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -1,4 +1,6 @@
 name: model jobs
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/132](https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/132)

To fix the problem, we should add an explicit `permissions` block to the workflow file `.github/workflows/model_jobs.yml`. This can be placed at the top level of the workflow, immediately after the `name:` and before the `on:` block, or at the individual job level (e.g., inside the `collated_reports` job). The best way is to use the top-level permissions block if all jobs have similar minimal needs, otherwise, place it for jobs that specifically need it. In this case, a minimal set such as `contents: read` will ensure these jobs only have read access to repository contents when using the GITHUB_TOKEN. If jobs upload artifacts, artifact permissions can also be specified if needed. The only change required is to insert:

```yaml
permissions:
  contents: read
```

after the workflow's `name:` field, covering all jobs. No additional methods, definitions, or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
