### PR TITLE
Potential fix for code scanning alert no. 130: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-nightly-ci-docker-images.yml
+++ b/.github/workflows/build-nightly-ci-docker-images.yml
@@ -1,4 +1,6 @@
 name: Build docker images (Nightly CI)
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/130](https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/130)

The fix is to add a `permissions` block to the workflow YAML file to explicitly limit the GitHub Actions `GITHUB_TOKEN` used in the workflow. Since the jobs only need to check out code (no writing to the repo, creating issues or PRs, or other write operations with the GITHUB_TOKEN), the token only needs `contents: read` permission. This can be added at the top workflow level, so it applies to all jobs, or at the job level (but top-level is simpler and more future-proof unless specific jobs need more permissions). The change involves adding the block directly after the `name: ...` field at the start. No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
