### PR TITLE
Potential fix for code scanning alert no. 159: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -1,4 +1,6 @@
 name: Nvidia CI (job definitions)
+permissions:
+  contents: read
 
 # Note that each job's dependencies go into a corresponding docker file.
 #


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/159](https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/159)

To fix this issue, we should add an explicit `permissions` block at the top level of the workflow file `.github/workflows/self-scheduled.yml`, immediately following the workflow `name` and before the `on:` block (recommended by GitHub docs). This sets a default minimal permission for `GITHUB_TOKEN`—usually `contents: read`—and restricts write access unless specifically required for certain jobs. If any job requires elevated privileges, a more generous `permissions` entry can be added at the job level. For now, the best fix is to set `contents: read` at the workflow level, which will apply to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
