### PR TITLE
Potential fix for code scanning alert no. 157: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -1,5 +1,8 @@
 name: Nvidia CI
 
+permissions:
+  contents: read
+
 on:
   repository_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/157](https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/157)

In general, to fix this kind of issue you explicitly set `permissions:` for the workflow (or per job) so that `GITHUB_TOKEN` has only the scopes required. For CI pipelines that mainly check out code, run tests, and maybe upload artifacts, `contents: read` is usually sufficient; write permissions (e.g. `contents: write`, `pull-requests: write`) should only be added if the workflow actually needs them.

The best fix here, without changing existing functionality, is to add a single `permissions:` block at the workflow root (between `name:` and `on:`) that sets `contents: read`. This will apply to all jobs in this workflow that do not override `permissions` individually, including `kernels-ci`. If any reused workflow or step actually requires broader permissions, that can later be adjusted in that specific job or in the reusable workflow, but with the information provided the safest reasonable default is read-only contents access.

Concretely, in `.github/workflows/self-scheduled-caller.yml`, insert:

```yaml
permissions:
  contents: read
```

after the existing `name: Nvidia CI` line and before the `on:` block. No additional imports, methods, or definitions are needed, as this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
