### PR TITLE
Potential fix for code scanning alert no. 160: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build_and_test:
     name: build release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/160](https://github.com/ReuelAlbert-Dev/transformers/security/code-scanning/160)

In general, the fix is to explicitly declare minimal `GITHUB_TOKEN` permissions for each job or at the workflow root, rather than relying on inherited defaults. For this workflow, `build_and_test` only needs to read the repository contents (for `actions/checkout`) and use artifacts; it does not push commits, modify issues, or publish releases. The `upload_package` job already declares `id-token: write` and otherwise relies on defaults; we will leave that as-is because the reported issue is specifically for `build_and_test`.

The best fix with no functional change is to add a `permissions` block to the `build_and_test` job, setting `contents: read`. This limits the job’s token to read-only access to the repository contents, which is sufficient for `actions/checkout@v4` and does not affect any of the Python build/test commands or artifact upload steps. Concretely, in `.github/workflows/release.yml`, under `jobs:`, within the `build_and_test` job and alongside `runs-on: ubuntu-latest`, we add:

```yaml
    permissions:
      contents: read
```

No imports or additional methods are needed since this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
